### PR TITLE
Add missing algorithm include

### DIFF
--- a/patricia.cpp
+++ b/patricia.cpp
@@ -4,6 +4,7 @@
  * Includes oftware developed by the University of Michigan,
  * Merit Network, Inc., and their contributors.
  */
+#include <algorithm> /* remove_if */
 #include <assert.h> /* assert */
 #include <ctype.h> /* isdigit */
 #include <errno.h> /* errno */


### PR DESCRIPTION
Fixes the following error during compilation:

```
patricia.cpp: In member function ‘int Patricia::parsePrefix(int, char*, std::string*)’:
patricia.cpp:1028:21: error: ‘remove_if’ is not a member of ‘std’; did you mean ‘remove_cv’?
 1028 |     line.erase(std::remove_if(line.begin(), line.end(), isspace), line.end());
      |                     ^~~~~~~~~
      |                     remove_cv
make[2]: *** [Makefile:650: patricia.o] Error 1
```