### PR TITLE
Filter IPv6 based on instance

### DIFF
--- a/listener6.cpp
+++ b/listener6.cpp
@@ -125,6 +125,12 @@ reloop:
                 if (icmp->is_yarrp) {
                     if (verbosity > LOW)
                         icmp->print();
+                    if (icmp->getInstance() != trace->config->instance) {
+                        if (verbosity > HIGH)
+                            cerr << ">> Listener: packet instance mismatch." << endl;
+                        delete icmp;
+                        continue;
+                    }
                     /* Fill mode logic. */
                     if (trace->config->fillmode) {
                         if ( (icmp->getTTL() >= trace->config->maxttl) and


### PR DESCRIPTION
Currently, incoming IPv6 packets are not filtered based on the instance similar to IPv4.
All instances receive and output all incoming packets resulting in a duplicate output.

The instance is already set in the sent payload and just has to be filtered.