### PR TITLE
Fix fill-mode behavior (v4) when receiving ICMP “Destination Unreachable” (!H) responses

### DIFF
--- a/listener.cpp
+++ b/listener.cpp
@@ -78,7 +78,10 @@ listener(void *args) {
                     if ( (icmp->getTTL() >= trace->config->maxttl) and
                          (icmp->getTTL() <= trace->config->fillmode) ) {
                         trace->stats->fills+=1;
-                        trace->probe(icmp->quoteDst(), icmp->getTTL() + 1); 
+                        uint32_t dst_ip = icmp->quoteDst();
+                        if (dst_ip != 0) {
+                            trace->probe(icmp->quoteDst(), icmp->getTTL() + 1); 
+                        }
                     }
                 }
                 icmp->write(&(trace->config->out), trace->stats->count);

--- a/listener.cpp
+++ b/listener.cpp
@@ -77,9 +77,9 @@ listener(void *args) {
                 if (trace->config->fillmode) {
                     if ( (icmp->getTTL() >= trace->config->maxttl) and
                          (icmp->getTTL() <= trace->config->fillmode) ) {
-                        trace->stats->fills+=1;
                         uint32_t dst_ip = icmp->quoteDst();
                         if (dst_ip != 0) {
+                            trace->stats->fills+=1;
                             trace->probe(icmp->quoteDst(), icmp->getTTL() + 1); 
                         }
                     }


### PR DESCRIPTION
Context: See #16 
Change: Update the fill mode logic in listener.cpp to not send a packet if quoteDst returns 0 (e.g., Destination Unreachable). 

Note: The fix is for IPv4 only. 
For v6, a similar fix still applies. But I haven't run into the same problem yet, and so I don't have test cases generating the same error. Thus, this PR addresses IPv4 only.